### PR TITLE
Fix wording in the `tidypolars` section

### DIFF
--- a/polars-rpy.qmd
+++ b/polars-rpy.qmd
@@ -403,7 +403,7 @@ nyc = con.table("nyc")
 
 ### tidypolars (R)
 
-The **tidypolars** package ([link](https://www.tidypolars.etiennebacher.com/)) provides a "tidyverse" backend for **polars** from R. The syntax and workflow should thus be immediately familar to R users.
+The R package **tidypolars** ([link](https://www.tidypolars.etiennebacher.com/)) provides the "tidyverse" syntax while using **polars** as backend. The syntax and workflow should thus be immediately familar to R users.
 
 It's important to note that **tidypolars** is _solely_ focused on the
 translation work. This means that you still need to load the main **polars**


### PR DESCRIPTION
It's the other way around: the `tidyverse` syntax is the frontend, `polars` is the backend ;)

Btw, `tidypolars` 0.10.0 (probably released in the next few days) will provide `scan_parquet_polars()` and `read_parquet_polars()` (and same for other formats) instead of `pl$scan_parquet()`  / `pl$read_parquet()`, which probably look a bit weird to the average R user. 

See the new "Import data" and "Export data" on the reference page: https://tidypolars.etiennebacher.com/reference/ (and let me know if you have any suggestions on the naming or anything else)